### PR TITLE
when creating the plane for node orientation now specify a static X a…

### DIFF
--- a/ClassLibrary1/WireFrameToRobot/Node.cs
+++ b/ClassLibrary1/WireFrameToRobot/Node.cs
@@ -206,7 +206,7 @@ namespace WireFrameToRobot
 
         private static string VectorRoundedString(Vector vec)
         {
-            return "X" + Math.Round(vec.X, 4).ToString() + "Y" + Math.Round(vec.X, 4).ToString() + "Z" + Math.Round(vec.X, 4).ToString();
+            return "X" + Math.Round(Math.Abs(vec.X), 4).ToString() + "Y" + Math.Round(Math.Abs(vec.Y), 4).ToString() + "Z" + Math.Round(Math.Abs(vec.Z), 4).ToString();
         }
 
         /// <summary>
@@ -365,7 +365,7 @@ namespace WireFrameToRobot
                         revd = Vector.ByCoordinates(0,0,1);
                     }
                     //reverse the normal so the top face is correct
-                     plane = Plane.ByOriginNormal(Center, revd);
+                     plane = Plane.ByOriginNormalXAxis(Center, revd, Vector.ByCoordinates(0,0,1));
                      newCs = CoordinateSystem.ByPlane(plane);
                    
                      output = originalGeometry.Transform(newCs) as Solid;


### PR DESCRIPTION
…xis for the node, I think this greatly improves issues we saw and lets us identify similar nodes more easily - Node orientations are now similar if their struts are similar instead of being undefined except for the normal.

also fix a bug in the hash for the nodeTypeFinder for vectors... was sadly using all X components for Y and Z.... :(